### PR TITLE
Updating galois

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,11 @@ license = "Apache-2.0"
 license-files = ["LICENSE"]
 dependencies = [
     # pin these for galois - otherwise build errors on 3.12
-    "llvmlite>=0.43.0",
-    "numba>=0.61.0",
+    # "llvmlite>=0.43.0",
+    # "numba>=0.61.0",
     
     "numpy",
-    "galois",
+    "galois > 0.4",
     "matplotlib",
     "scipy",
     "sympy",


### PR DESCRIPTION
We are having issues with the galois dependencies related to numpy and the old pins. This PR will solve them.